### PR TITLE
-f option: stop on any failure of the stage executions

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -30,6 +30,9 @@ go test -v ./plumber -race || exit 1
 go test -i ./stages || exit 1
 go test -v ./stages -race || exit 1
 
+go test -i ./engine || exit 1
+go test -v ./engine -race || exit 1
+
 #go test -i ./tests/functional
 #ETCD_BIN_PATH=$(pwd)/bin/plumber go test -v ./tests/functional -race
 


### PR DESCRIPTION
Default behaviors:

```
13:39:47  INFO geting starting to run pipeline process...
13:39:47  INFO [command] exec: echxxxo "hello, world"
13:39:47  INFO [command] output: sh: echxxxo: command not found
13:39:47 ERROR [command] err: exit status 127
13:39:47 WARNING execution is skipped: command_stage_2_group_1
13:39:47 WARNING execution is skipped: command_stage_3_group_1
13:39:47 WARNING execution is skipped: command_stage_3_group_2
13:39:47 WARNING execution is skipped: command_stage_4
13:39:47 WARNING execution is skipped: command_stage_5
13:39:47  INFO finished to run pipeline process...
13:39:47  INFO succeded to finish Plumber
```

Otherwise, if '-f ' option is enabled, execute subsequent stages even though stage execution fails

```
14:22:19  INFO running Plumber
14:22:19  INFO geting starting to run pipeline process...
14:22:19  INFO [command] exec: echxxxo "hello, world"
14:22:19  INFO [command] output: sh: echxxxo: command not found
14:22:19 ERROR [command] err: exit status 127
14:22:19  INFO [command] exec: echo "hello, world, command_stage_2_group_1"
14:22:19  INFO [command] exec: echo "hello, world, command_stage_3_group_1"
14:22:19  INFO [command] output: hello, world, command_stage_2_group_1
14:22:19  INFO [command] output: hello, world, command_stage_3_group_1
14:22:19  INFO [command] exec: echo "hello, world, command_stage_3_group_2"
14:22:19  INFO [command] output: hello, world, command_stage_3_group_2
14:22:19  INFO [command] exec: echo "hello, world" && sleep 1
14:22:19  INFO [command] output: hello, world
14:22:20  INFO [command] exec: echo "hello, world, command_stage_3_group_1"
14:22:20  INFO [command] output: hello, world, command_stage_3_group_1
14:22:20  INFO finished to run pipeline process...
14:22:20  INFO succeded to finish Plumber
```
