### PR TITLE
Add a property to specify the directory where commands are run

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,6 +42,21 @@ func TestReadConfigBytes(t *testing.T) {
 	assert.Equal(t, "echo \"hello, world\"", actual)
 }
 
+func TestReadConfigWithDirectory(t *testing.T) {
+	configStr :=
+		`pipeline:
+    - stage_name: command_stage_1
+      stage_type: command
+      command: echo "hello, world"
+      directory: /user/local/bin
+`
+	configBytes := []byte(configStr)
+	configData := *ReadConfigBytes(configBytes)
+	actual := configData["pipeline"].([]interface{})[0].(map[interface{}]interface{})["directory"]
+
+	assert.Equal(t, "/user/local/bin", actual)
+}
+
 func TestReadConfigWithChildren(t *testing.T) {
 	configStr :=
 		`pipeline:

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -59,3 +59,15 @@ func TestParseConfWithChildren(t *testing.T) {
 	childStages := result.Stages.Front().Value.(stages.Stage).GetChildStages()
 	assert.Equal(t, 2, childStages.Len())
 }
+
+func TestParseConfWithDirectory(t *testing.T) {
+	configData := ReadConfigBytes([]byte(`pipeline:
+    - stage_name: command_stage_1
+      stage_type: command
+      command: ls -l
+      directory: /usr/local
+`))
+	result := Parse(configData)
+	actual := result.Stages.Front().Value.(*stages.CommandStage).Directory
+	assert.Equal(t, "/usr/local", actual)
+}

--- a/stages/command_stage.go
+++ b/stages/command_stage.go
@@ -27,6 +27,7 @@ import (
 type CommandStage struct {
 	BaseStage
 	Command   string `config:"command"`
+	Directory string `config:"directory"`
 	OutResult string
 	ErrResult string
 }
@@ -38,7 +39,7 @@ func (self *CommandStage) GetStdoutResult() string {
 func (self *CommandStage) Run() bool {
 	cmd := exec.Command("sh", "-c", self.Command)
 	log.Infof("[command] exec: %s", self.Command)
-	cmd.Dir = "."
+	cmd.Dir = self.Directory
 	out, err := cmd.StdoutPipe()
 	outE, errE := cmd.StderrPipe()
 
@@ -95,7 +96,11 @@ func (self *CommandStage) AddCommand(command string) {
 	self.BaseStage.Runner = self
 }
 
+func (self *CommandStage) SetDirectory(directory string) {
+	self.Directory = directory
+}
+
 func NewCommandStage() *CommandStage {
-	stage := CommandStage{}
+	stage := CommandStage{Directory: "."}
 	return &stage
 }

--- a/stages/command_stage_test.go
+++ b/stages/command_stage_test.go
@@ -52,3 +52,11 @@ func TestStdoutRsultOfCommand(t *testing.T) {
 	stage.Run()
 	assert.Equal(t, "foobar\n", stage.GetStdoutResult())
 }
+
+func TestStdoutRsultOfCommandFromSpecifiedDirectory(t *testing.T) {
+	stage := NewCommandStage()
+	stage.SetDirectory("..")
+	stage.AddCommand("ls")
+	stage.Run()
+	assert.Contains(t, stage.GetStdoutResult(), "README.md")
+}


### PR DESCRIPTION
I added a new property "directory", which is useful to support other command specific stages described in #6 , #7.
