### PR TITLE
stages: use CommandStage as stage_type default

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -101,7 +101,12 @@ func convertYamlMapToStages(yamlStageList []interface{}) *list.List {
 
 func mapStage(stageMap map[interface{}]interface{}) stages.Stage {
 	log.Debugf("%v", stageMap["run_after"])
-	stageType := stageMap["stage_type"].(string)
+
+	var stageType string
+	if stageMap["stage_type"] != nil {
+		stageType = stageMap["stage_type"].(string)
+	}
+
 	stage := stages.InitStage(stageType)
 	newStageValue := reflect.ValueOf(stage).Elem()
 	newStageType := reflect.TypeOf(stage).Elem()

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -66,6 +66,17 @@ func TestParseConfWithChildren(t *testing.T) {
 	assert.Equal(t, 2, childStages.Len())
 }
 
+func TestParseConfDefaultStageTypeIsCommand(t *testing.T) {
+	configData := ReadConfigBytes([]byte(`pipeline:
+    - stage_name: command_stage_1
+      command: echo "hello, world"
+`))
+	result, err := Parse(configData)
+	actual := result.Stages.Front().Value.(*stages.CommandStage).Command
+	assert.Equal(t, "echo \"hello, world\"", actual)
+	assert.Nil(t, err)
+}
+
 func TestParseConfWithDirectory(t *testing.T) {
 	configData := ReadConfigBytes([]byte(`pipeline:
     - stage_name: command_stage_1

--- a/stages/stage.go
+++ b/stages/stage.go
@@ -41,6 +41,8 @@ type Mediator struct {
 func InitStage(stageType string) Stage {
 	var stage Stage
 	switch stageType {
+	default:
+		stage = new(CommandStage)
 	case "command":
 		stage = new(CommandStage)
 	case "shell":


### PR DESCRIPTION
If it isn't specified `stage_type` in `stage:`, `stage_type` is determined to be `CommandStage`.
