### PR TITLE
Add command line parameters for logging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,13 +38,23 @@ func LoadOpts(arguments []string) (*Opts, error) {
 	var pipelineFilePath string
 	var stopOnAnyFailure bool
 	var printVersion bool
+	var threshold string
+	var log_dir string
 
 	fs.StringVar(&pipelineFilePath, "c", "./pipeline.yml", "pipeline.yml file")
 	fs.BoolVar(&stopOnAnyFailure, "f", false, "Skip execution of subsequent stage after failing to exec the upstream stage.")
 	fs.BoolVar(&printVersion, "v", false, "Print the version information and exit.")
+	fs.StringVar(&threshold, "threshold", "INFO", "Log events at or above this severity are logged.")
+	fs.StringVar(&log_dir, "log_dir", "", "Log files will be written to this directory.")
 
 	if err := fs.Parse(arguments); err != nil {
 		return nil, err
+	}
+
+	flag.CommandLine.Lookup("stderrthreshold").Value.Set(threshold)
+
+	if log_dir != "" {
+		flag.CommandLine.Lookup("log_dir").Value.Set(log_dir)
 	}
 
 	return &Opts{

--- a/log/glog_recorder.go
+++ b/log/glog_recorder.go
@@ -17,6 +17,11 @@ func (l *GlogRecorder) Info(m string) {
 func (l *GlogRecorder) Error(m string) {
 	glog.Error(m)
 }
+
 func (l *GlogRecorder) Warn(m string) {
 	glog.Warning(m)
+}
+
+func (l *GlogRecorder) Flush() {
+	glog.Flush()
 }

--- a/log/log.go
+++ b/log/log.go
@@ -9,6 +9,7 @@ type Recorder interface {
 	Debug(m string)
 	Warn(m string)
 	Error(m string)
+	Flush()
 }
 
 func Debug(m string) {
@@ -49,4 +50,8 @@ func Errorf(m string, args ...interface{}) {
 
 func Init(recorder Recorder) {
 	GlobalRecorder = recorder
+}
+
+func Flush() {
+	GlobalRecorder.Flush()
 }

--- a/main.go
+++ b/main.go
@@ -55,7 +55,9 @@ func main() {
 	result := walter.Run()
 	if result == false {
 		log.Info("more than one failures were detected running Walter")
+		log.Flush()
 		os.Exit(1)
 	}
 	log.Info("succeded to finish Walter")
+	log.Flush()
 }

--- a/walter/walter.go
+++ b/walter/walter.go
@@ -47,5 +47,9 @@ func New(opts *config.Opts) (*Walter, error) {
 
 func (e *Walter) Run() bool {
 	mediator := e.Engine.RunOnce()
-	return mediator.IsAnyFailure()
+	if mediator.IsAnyFailure() == true {
+		return false
+	} else {
+		return true
+	}
 }


### PR DESCRIPTION
I added logging parameters, "threshold" and "log_dir."
- log_dir specifies the directory to flush logs
- threshold specifies the logging level

The following is a example of the parameters.

```
bin/walter -c tests/fixtures/pipeline.yml --threshold=Info --log_dir=tmp 
```
