### PR TITLE
Add context string when updating github repo status

### DIFF
--- a/services/github.go
+++ b/services/github.go
@@ -51,6 +51,7 @@ func (self *GitHubClient) RegisterResult(result Result) error {
 			State: github.String(result.State),
 			TargetURL: github.String(""),
 			Description: github.String(result.Message),
+		    Context: github.String("continuous-integraion/walter"),
 	})
 	log.Infof("submit status: %s", status)
 	if err != nil {


### PR DESCRIPTION
This pull request adds the string `continuous-intgration/walter` on the build status like this.

![context](https://cloud.githubusercontent.com/assets/3620/6127990/6b32bcee-b174-11e4-99ff-d8d7598cc04c.png)
