### PR TITLE
Support environment variables in the Walter configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,23 @@ The following shows the description of each element.
 |   repo    |  Repository name                                                                                     |
 |   from    |  Account or organization name (if the repository is own by a organization)                           |
 |   update  |  Update file which contains the result and time of the last execution                                |
+
+## Embedding of Environment Variables
+
+Users add environment variables in Walter configuration files. The names of environment variables are expanted into the the values of environment variables.
+Environment variables in the configuration files are valuable when we need to write the sensitive information such as
+tokens of messenger service or passwords of a external systems.
+
+The following is the format of embedding of the environment variables.
+
+     ${env.ENV_NAME}
+
+We write the envrionment variable into **ENV_NAME**. The following configuration file specify the GitHub Token by embedding the environment variable, GITHUB_TOKEN.
+
+    service:
+        type: github
+        token: ${env.GITHUB_TOKEN}
+        repo: my-service-repository
+        from: service-group
+        update: .walter
+

--- a/config/envvar.go
+++ b/config/envvar.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/recruit-tech/walter/log"
 )
 
 type EnvVariables struct {
@@ -56,6 +58,9 @@ func (self *EnvVariables) regexReplace(input string) string {
 	if len(matched) == 2 {
 		if replaced := (*self.variables)[matched[1]]; replaced != "" {
 			return replaced
+		} else {
+			log.Warnf("NO environment variable: %s", matched[0])
+			return ""
 		}
 	}
 	return input

--- a/config/envvar.go
+++ b/config/envvar.go
@@ -1,0 +1,32 @@
+/* walter: a deployment pipeline template
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+//NOTE: maybe env map should be singleton in the future.
+func LoadEnvMap() map[string]string {
+	envs := make(map[string]string)
+	for _, envVal := range os.Environ() {
+		curEnv := strings.Split(envVal, "=")
+		envs[curEnv[0]] = curEnv[1]
+	}
+	return envs
+}

--- a/config/envvar_test.go
+++ b/config/envvar_test.go
@@ -23,14 +23,42 @@ import (
 )
 
 func TestEnvAccess(t *testing.T) {
-	env := LoadEnvMap()
-	path, ok := env["GOPATH"]
+	envs := NewEnvVariables()
+	path, ok := envs.Get("GOPATH")
 	assert.True(t, ok)
 	assert.True(t, len(path) > 0)
 }
 
 func TestEnvAccessNoExist(t *testing.T) {
-	env := LoadEnvMap()
-	_, ok := env["NO_SUCH_A_ENV_VARIABLE"]
+	envs := NewEnvVariables()
+	_, ok := envs.Get("NO_SUCH_A_ENV_VARIABLE")
 	assert.False(t, ok)
+}
+
+func TestReplaceLineWithEnvVariable(t *testing.T) {
+	envs := NewEnvVariables()
+	envs.Add("SLACK_CHANNEL", "foobar")
+	result := envs.Replace("path: ${env.SLACK_CHANNEL}")
+	assert.Equal(t, "path: foobar", result)
+}
+
+func TestReplaceMultipleItemsLineWithEnvVariable(t *testing.T) {
+	envs := NewEnvVariables()
+	envs.Add("PATH", "/usr/:/usr/local")
+	envs.Add("LOCAL", "en")
+	result := envs.Replace("${env.PATH} is set for ${env.LOCAL}")
+	assert.Equal(t, "/usr/:/usr/local is set for en", result)
+}
+
+func TestReplaceWithoutWhiteSpace(t *testing.T) {
+	envs := NewEnvVariables()
+	envs.Add("PATH", "/usr/:/usr/local")
+	result := envs.Replace("${env.PATH}:/opt")
+	assert.Equal(t, "/usr/:/usr/local:/opt", result)
+}
+
+func TestVoidInput(t *testing.T) {
+	envs := NewEnvVariables()
+	result := envs.Replace("")
+	assert.Equal(t, "", result)
 }

--- a/config/envvar_test.go
+++ b/config/envvar_test.go
@@ -1,0 +1,36 @@
+/* walter: a deployment pipeline template
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvAccess(t *testing.T) {
+	env := LoadEnvMap()
+	path, ok := env["GOPATH"]
+	assert.True(t, ok)
+	assert.True(t, len(path) > 0)
+}
+
+func TestEnvAccessNoExist(t *testing.T) {
+	env := LoadEnvMap()
+	_, ok := env["NO_SUCH_A_ENV_VARIABLE"]
+	assert.False(t, ok)
+}

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -169,3 +169,54 @@ func TestParseConfWithServiceBlock(t *testing.T) {
 	assert.Equal(t, "walter", service.Repo)
 	assert.Equal(t, "yyyy", service.From)
 }
+
+func TestParseConfWithEnvVariable(t *testing.T) {
+	configData := ReadConfigBytes([]byte(`pipeline:
+    - stage_name: command_stage_1
+      command: echo "hello ${env.USER_NAME}-san"
+`))
+
+	envs := NewEnvVariables()
+	envs.Add("USER_NAME", "takahi-i")
+	result, err := ParseWithSpecifiedEnvs(configData, envs)
+	actual := result.Stages.Front().Value.(*stages.CommandStage).Command
+	assert.Equal(t, "echo \"hello takahi-i-san\"", actual)
+	assert.Nil(t, err)
+}
+
+func TestParseConfWithNoExistEnvVariable(t *testing.T) {
+	configData := ReadConfigBytes([]byte(`pipeline:
+    - stage_name: command_stage_1
+      command: echo "hello ${env.NO_SUCH_A_ENV_VARIABLE}"
+`))
+
+	envs := NewEnvVariables()
+	envs.Add("USER_NAME", "takahi-i")
+	result, err := ParseWithSpecifiedEnvs(configData, envs)
+	actual := result.Stages.Front().Value.(*stages.CommandStage).Command
+	assert.Equal(t, "echo \"hello ${env.NO_SUCH_A_ENV_VARIABLE}\"", actual)
+	assert.Nil(t, err)
+}
+
+func TestParseMessengerConfWithEnvVariable(t *testing.T) {
+	configData := ReadConfigBytes([]byte(`
+    messenger:
+           type: hipchat
+           room_id: foobar
+           token: ${env.HIPCHAT_TOKEN}
+           from: yyyy
+    pipeline:
+        - stage_name: command_stage_1
+          stage_type: shell
+          file: ../stages/test_sample.sh
+`))
+	envs := NewEnvVariables()
+	envs.Add("HIPCHAT_TOKEN", "this-token-is-very-secret")
+	result, err := ParseWithSpecifiedEnvs(configData, envs)
+	messenger, ok := result.Reporter.(*messengers.HipChat)
+	assert.Nil(t, err)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, "foobar", messenger.RoomId)
+	assert.Equal(t, "this-token-is-very-secret", messenger.Token)
+	assert.Equal(t, "yyyy", messenger.From)
+}

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -194,7 +194,7 @@ func TestParseConfWithNoExistEnvVariable(t *testing.T) {
 	envs.Add("USER_NAME", "takahi-i")
 	result, err := ParseWithSpecifiedEnvs(configData, envs)
 	actual := result.Stages.Front().Value.(*stages.CommandStage).Command
-	assert.Equal(t, "echo \"hello ${env.NO_SUCH_A_ENV_VARIABLE}\"", actual)
+	assert.Equal(t, "echo \"hello \"", actual) // NOTE: No env variable name is shown when there is no env variable
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
Motivation is discussed in #67. 

The following is a sample the format of configuration files with environment variables.

Sample
=========

    messenger:
          type: ${env.MESSENGER_TYPE}
          channel: ${env.SLACK_CHANNEL}
    service:
          type: github
          token: ${env.GITHUB_KEY}
    pipeline:
              - stage_name: command_stage_1
                stage_type: command
                command: echo "hello, world"
                run_after:
                -  stage_name: command_stage_2_group_1
                   stage_type: command
                   command: echo "${JAVA_HOME}-desu"
                -  stage_name: command_stage_3_group_1
                   stage_type: command
                   command: echo "hello, world, command_stage_3_group_1"

NOTE
==========
Environment variables are not supported in **block key** in the yaml formatted file.
For example, the following configuration is invalid

    ${env.BLOCKNAME} : command

