### PR TITLE
Fix runtime error when running walter without service block

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ func LoadOpts(arguments []string) (*Opts, error) {
 	fs.BoolVar(&printVersion, "v", false, "Print the version information and exit.")
 	fs.StringVar(&threshold, "threshold", "INFO", "Log events at or above this severity are logged.")
 	fs.StringVar(&log_dir, "log_dir", "", "Log files will be written to this directory.")
-	fs.StringVar(&mode, "mode", "", "Execution mode (local or service).")
+	fs.StringVar(&mode, "mode", "local", "Execution mode (local or service).")
 
 	if err := fs.Parse(arguments); err != nil {
 		return nil, err

--- a/walter/walter.go
+++ b/walter/walter.go
@@ -54,10 +54,15 @@ func New(opts *config.Opts) (*Walter, error) {
 }
 
 func (e *Walter) Run() bool {
-	if e.Engine.Opts.Mode == "local" {
+	repoServiceValue := reflect.ValueOf(e.Engine.Pipeline.RepoService)
+	log.Info(repoServiceValue.Type().String())
+	if e.Engine.Opts.Mode == "local" ||
+		repoServiceValue.Type().String() == "*services.LocalClient" {
+		log.Info("start walter in local mode")
 		mediator := e.Engine.RunOnce()
 		return !mediator.IsAnyFailure()
 	} else {
+		log.Info("start walter in repository service mode")
 		return e.runService()
 	}
 }


### PR DESCRIPTION
I fixed a runtime error, which occurs when the specified configuration file does not have **service** block.

    17:03:23  INFO Not found "service" block
    17:03:23  INFO local client was created
    17:03:23  INFO Not found messenger block
    17:03:23  INFO running Walter
    17:03:23  INFO loading update file... ""
    17:03:23  INFO opening file: ""...
    17:03:23  WARN error occured opening file: "" ...
    17:03:23  WARN open : no such file or directory
    17:03:23  WARN continue the process with the new settings
    17:03:23  INFO succeeded to load update file
    17:03:23  INFO updating status...
    17:03:23  INFO writing down new update: ""
    17:03:23 ERROR failed to write update to file...: "open : no such file or directory"
    17:03:23 ERROR failed to save status update
    17:03:23  INFO more than one failures were detected running Walter