### PR TITLE
Fix: avoid `Permission denied (publickey).` on wercker.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -13,7 +13,7 @@ build:
         - script:
             name: output release tag
             code: |
-                git pull --tags && git describe --tags --exact --match 'v*' > $WERCKER_OUTPUT_DIR/.release_tag || true
+                git describe --tags --exact --match 'v*' > $WERCKER_OUTPUT_DIR/.release_tag || true
 deploy:
   steps:
     # reference: https://github.com/motemen/ghq/blob/beee539aead9c3940a0c4706357c5753999f6c85/wercker.yml


### PR DESCRIPTION
Hi,
I have fixed output release tag step on werkcer .

If it's alright, please add tag after implementing the interesting features and release from the wercker.
F.Y.I. An auto deployment was success on my fork [higanworks/walter/releases](https://github.com/higanworks/walter/releases).