### PR TITLE
Improve wercker release flow

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: motemen/golang-goxc@0.1.0
+box: ainoya/golang-goxc@0.2.0
 build:
     steps:
         - script:
@@ -10,17 +10,13 @@ build:
             code: |
                 . ./build
                 goxc -tasks='xc archive' -n walter -bc='linux,!arm windows darwin' -main-dirs-exclude='gopath,Godeps,tests' -d ${WERCKER_OUTPUT_DIR} -build-ldflags "-X ${REPO_PATH}/version.Version \"$(git describe --tags --always --dirty)\""
-        - script:
-            name: output release tag
-            code: |
-                git describe --tags --exact --match 'v*' > $WERCKER_OUTPUT_DIR/.release_tag || true
 deploy:
   steps:
     # reference: https://github.com/motemen/ghq/blob/beee539aead9c3940a0c4706357c5753999f6c85/wercker.yml
     - script:
-        name: restore release tag
+        name: fetch release tag
         code: |
-          export RELEASE_TAG=$(cat .release_tag)
+            export RELEASE_TAG=$(curl https://api.github.com/repos/walter-cd/walter/tags | jq -r ".[] | select(.commit.sha == \"${WERCKER_GIT_COMMIT}\") | .name")
     - wercker/github-create-release:
         token: $GITHUB_TOKEN
         tag: $RELEASE_TAG


### PR DESCRIPTION
By this improvement, even after `git push` without release tag,  we can put git tag later and release by the tag with using `deploy to` wercker task.

**New release flow**

1. Merge this PR(only once)
2. Wait for passing wercker builds
3. Put release tag on latest commit-id with `git tag` command locally
4. Update remote tags on github with `git push --tags`
5. Kick `Deploy to` button on the wercker job corresponding to tagged commit-id