### PR TITLE
Support icon_url of Slack incoming webhook

### DIFF
--- a/messengers/slack.go
+++ b/messengers/slack.go
@@ -29,6 +29,7 @@ type Slack struct {
 	Channel   string   `config:"channel" json:"channel"`
 	UserName  string   `config:"username" json:"username"`
 	IconEmoji string   `config:"icon" json:"icon_emoji,omitempty"`
+	IconUrl   string   `config:"icon_url" json:"icon_url,omitempty"`
 	IncomingUrl string `config:"url" json:"-"` // not map to json
 }
 


### PR DESCRIPTION
With this PR, you can set `icon_url` when notifying to Slack.
