### PR TITLE
Report skipped status as "skipped", not "false"

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -18,7 +18,6 @@ package engine
 
 import (
 	"container/list"
-	"fmt"
 	"strconv"
 
 	"github.com/recruit-tech/walter/config"
@@ -96,7 +95,7 @@ func (e *Engine) ExecuteStage(stage stages.Stage) {
 	e.Resources.ReportStageResult(stage, result)
 
 	mediator := stages.Mediator{States: make(map[string]string)}
-	mediator.States[stage.GetStageName()] = fmt.Sprintf("%v", result)
+	mediator.States[stage.GetStageName()] = result
 
 	if childStages := stage.GetChildStages(); childStages.Len() > 0 {
 		log.Debugf("Execute childstage: %v", childStages)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"container/list"
 	"fmt"
+	"strconv"
 
 	"github.com/recruit-tech/walter/config"
 	"github.com/recruit-tech/walter/log"
@@ -84,12 +85,12 @@ func (e *Engine) ExecuteStage(stage stages.Stage) {
 	log.Debugf("Execute as parent: %+v", stage)
 	log.Debugf("Execute as parent name %+v", stage.GetStageName())
 
-	var result bool
+	var result string
 	if !e.isUpstreamAnyFailure(mediatorsReceived) || e.Opts.StopOnAnyFailure {
-		result = stage.(stages.Runner).Run()
+		result = strconv.FormatBool(stage.(stages.Runner).Run())
 	} else {
 		log.Warnf("Execution is skipped: %v", stage.GetStageName())
-		result = false
+		result = "skipped"
 	}
 	log.Debugf("Stage execution results: %+v, %+v", stage.GetStageName(), result)
 	e.Resources.ReportStageResult(stage, result)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -160,7 +160,7 @@ func TestRunOnceWithOptsOffStopOnAnyFailure(t *testing.T) {
 	}
 	result := engine.RunOnce()
 
-	assert.Equal(t, "false", result.Pipeline.States["echo foobar2"])
+	assert.Equal(t, "skipped", result.Pipeline.States["echo foobar2"])
 	assert.Equal(t, true, result.Pipeline.IsAnyFailure())
 }
 

--- a/pipelines/pipeline.go
+++ b/pipelines/pipeline.go
@@ -36,7 +36,7 @@ type Resources struct {
 	RepoService services.Service
 }
 
-func (self *Resources) ReportStageResult(stage stages.Stage, result bool) {
+func (self *Resources) ReportStageResult(stage stages.Stage, result string) {
 	name := stage.GetStageName()
 	self.Reporter.Post(
 		fmt.Sprintf("Stage execution results: %+v, %+v", name, result))

--- a/pipelines/pipeline_test.go
+++ b/pipelines/pipeline_test.go
@@ -69,7 +69,7 @@ func TestReportStageResult(t *testing.T) {
 
 	stage.SetStageOpts(*opts)
 
-	p.ReportStageResult(stage, true)
+	p.ReportStageResult(stage, "true")
 
 	assert.Equal(t, 1, len(mock.Posts))
 }
@@ -89,7 +89,7 @@ func TestReportStageResultWithFullOutput(t *testing.T) {
 
 	stage.SetStageOpts(*opts)
 
-	p.ReportStageResult(stage, true)
+	p.ReportStageResult(stage, "true")
 
 	assert.Equal(t, 2, len(mock.Posts))
 }


### PR DESCRIPTION
Walter reports skipped stage as "false" like this:

![skipped-as-false](https://cloud.githubusercontent.com/assets/3620/7788089/f58321a6-0267-11e5-8602-1677d54c382e.png)

The result of **parallel command 1** is false, so the last stage **command 2** is skipped. But it's status is reported as **false**.

With this PR, Walter reports skipped stage as "skipped".
