### PR TITLE
Add base_url support for hipchat2 private servers

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -20,7 +20,7 @@
 		},
 		{
 			"ImportPath": "github.com/tbruyelle/hipchat-go/hipchat",
-			"Rev": "c2364b4acfdeb7bb4ce232fa53bc80b5d741d668"
+			"Rev": "7fdd5b2bf90aef87fd0fb5238b0fa72559e11736"
 		},
 		{
 			"ImportPath": "github.com/google/go-github/github",

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The following is the parameter of Shell script stage.
 ## Parallel stages
 
  You can set child stages and run these stages in parallel like this.
- 
+
 ```yaml
 pipeline:
   - name: parallel stages
@@ -145,7 +145,8 @@ To submit a message, users need to add a **messenger** block into the configurat
 
 ```yaml
 messenger:
-  type: hipchat
+  type: hipchat2
+  base_url: BASE_URL
   room_id: ROOM_ID
   token: TOKEN
   from: USER_NAME
@@ -185,6 +186,7 @@ To activate the report function, we need to specify the properties for messenger
 |   room_id        |  Room name                        |
 |   token          |  HipChat token                    |
 |   from           |  Account name                     |
+|   base_url       |  Base API URL (for private servers; hipchat2 only) |
 
 #### slack
 


### PR DESCRIPTION
This pull request addresses https://github.com/walter-cd/walter/issues/47 by adding support for HipChat on-premises (private) servers to the `hipchat2` messenger by doing the following:

- bumping the godep for https://github.com/tbruyelle/hipchat-go to match upstream v1.0, which exposes BaseURL
- adding a configuration field to the hipchat2 messenger, `base_url`
- documenting the change in the README.md

The other `hipchat` messenger also supports BaseURL in their client, as of https://github.com/andybons/hipchat/commit/0fd4d621380d2b040f1ee141c8653f3fc7346484 but it has not been tagged as a release, so I did not include version 1 support.

I have verified this change works with our on-premises server.