### PR TITLE
update godeps.json to include missing dependencies

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,34 +1,61 @@
 {
-	"ImportPath": "github.com/recruit-tech/walter",
+	"ImportPath": ".",
 	"GoVersion": "go1.3",
+	"Packages": [
+		"github.com/go-yaml/yaml",
+		"github.com/ainoya/glog",
+		"github.com/stretchr/testify",
+		"github.com/andybons/hipchat",
+		"github.com/tbruyelle/hipchat-go/hipchat",
+		"github.com/google/go-github/github",
+		"code.google.com/p/goauth2/oauth",
+		"github.com/stretchr/objx",
+		"github.com/google/go-querystring/query"
+	],
 	"Deps": [
 		{
-			"ImportPath": "github.com/go-yaml/yaml",
-			"Rev": "1b9791953ba4027efaeb728c7355e542a203be5e"
+			"ImportPath": "code.google.com/p/goauth2/oauth",
+			"Rev": "afe77d958c70"
 		},
 		{
 			"ImportPath": "github.com/ainoya/glog",
 			"Rev": "20260dceee553e514cce6bdaea44664cc4398759"
 		},
 		{
-			"ImportPath": "github.com/stretchr/testify",
-			"Rev": "de7fcff264cd05cc0c90c509ea789a436a0dd206"
-		},
-		{
 			"ImportPath": "github.com/andybons/hipchat",
 			"Rev": "08bf65eade11bf8d584e933d01a35c2799c36ff4"
 		},
 		{
-			"ImportPath": "github.com/tbruyelle/hipchat-go/hipchat",
-			"Rev": "7fdd5b2bf90aef87fd0fb5238b0fa72559e11736"
+			"ImportPath": "github.com/go-yaml/yaml",
+			"Rev": "1b9791953ba4027efaeb728c7355e542a203be5e"
 		},
 		{
 			"ImportPath": "github.com/google/go-github/github",
 			"Rev": "1e55bf6be814270d7cc31a60868c4bd89e4e68c0"
 		},
 		{
-			"ImportPath": "code.google.com/p/goauth2/oauth",
-			"Rev": "afe77d958c70"
+			"ImportPath": "github.com/google/go-querystring/query",
+			"Rev": "2a60fc2ba6c19de80291203597d752e9ba58e4c0"
+		},
+		{
+			"ImportPath": "github.com/stretchr/objx",
+			"Rev": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94"
+		},
+		{
+			"ImportPath": "github.com/stretchr/testify",
+			"Rev": "de7fcff264cd05cc0c90c509ea789a436a0dd206"
+		},
+		{
+			"ImportPath": "github.com/tbruyelle/hipchat-go/hipchat",
+			"Rev": "7fdd5b2bf90aef87fd0fb5238b0fa72559e11736"
+		},
+		{
+			"ImportPath": "gopkg.in/check.v1",
+			"Rev": "11d3bc7aa68e238947792f30573146a3231fc0f1"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v1",
+			"Rev": "9f9df34309c04878acc86042b16630b0f696e1de"
 		}
 	]
 }


### PR DESCRIPTION
A clean build of walter following the README.md results in the following errors:

```
godep: Dep (github.com/stretchr/testify) restored, but was unable to load it with error:
	Package (github.com/stretchr/objx) not found
godep: Dep (github.com/google/go-github/github) restored, but was unable to load it with error:
	Package (github.com/google/go-querystring/query) not found
godep: Error checking some deps.
```

The version of godep built by walter was `godep v44 (linux/amd64/go1.4.2)`.  The problem can be reproduced using the following:

```
build@scdunlop ~/build> env  | grep '^GO'
build@scdunlop ~/build> git clone https://github.com/walter-cd/walter
Cloning into 'walter'...
remote: Counting objects: 1577, done.
remote: Total 1577 (delta 0), reused 0 (delta 0), pack-reused 1577
Receiving objects: 100% (1577/1577), 306.90 KiB | 0 bytes/s, done.
Resolving deltas: 100% (917/917), done.
Checking connectivity... done.
build@scdunlop ~/build> cd walter/
build@scdunlop ~/b/walter> ./build
godep: Dep (github.com/stretchr/testify) restored, but was unable to load it with error:
	Package (github.com/stretchr/objx) not found
godep: Dep (github.com/google/go-github/github) restored, but was unable to load it with error:
	Package (github.com/google/go-querystring/query) not found
godep: Error checking some deps.
```

The fix appears to be injecting the three missing dependencies via godeps and regenerating `godeps.json`; this pull request updates the `godeps.json` and walter builds successfully.  (I might have done things a bit backwards, godeps is novel for me.)