### PR TITLE
Add BaseStage.SetReturnValue() to set return value

### DIFF
--- a/stages/base_stage.go
+++ b/stages/base_stage.go
@@ -152,3 +152,8 @@ func (b *BaseStage) SetErrResult(result string) {
 func (b *BaseStage) GetReturnValue() bool {
 	return b.ReturnValue
 }
+
+// SetReturnValue sets return value of the stage
+func (b *BaseStage) SetReturnValue(value bool) {
+	b.ReturnValue = value
+}

--- a/stages/command_stage.go
+++ b/stages/command_stage.go
@@ -76,6 +76,7 @@ func (commandStage *CommandStage) runCommand() bool {
 	result, outResult, errResult := execCommand(cmd, "exec", commandStage.BaseStage.StageName)
 	commandStage.SetOutResult(*outResult)
 	commandStage.SetErrResult(*errResult)
+	commandStage.SetReturnValue(result)
 	return result
 }
 


### PR DESCRIPTION
Without this code, `stage.Value.(*stages.CommandStage).GetReturnValue()` returns `false` even though the stage succeeded.

@takahi-i Please check this.