### PR TITLE
Set TargetUrl to show the link to walter-server result page

### DIFF
--- a/services/github.go
+++ b/services/github.go
@@ -60,7 +60,7 @@ func (githubClient *GitHubClient) RegisterResult(result Result) error {
 		result.SHA,
 		&github.RepoStatus{
 			State:       github.String(result.State),
-			TargetURL:   github.String(""),
+			TargetURL:   github.String(result.Url),
 			Description: github.String(result.Message),
 			Context:     github.String("continuous-integraion/walter"),
 		})

--- a/services/service.go
+++ b/services/service.go
@@ -49,6 +49,7 @@ type Result struct {
 	State   string
 	SHA     string
 	Message string
+	Url     string
 }
 
 // DEFAULT_UPDATE_FILE_NAME is the default file name of status of Walter service.


### PR DESCRIPTION
To jump to walter-server result page directly from GitHub, I've added `Url` field to `services.Result` and set this field value to `TargetUrl` of `github.RepoStatus` .