### PR TITLE
Replace OAuth libaries from deprecated one to fix a build error

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,61 +1,66 @@
 {
-	"ImportPath": ".",
-	"GoVersion": "go1.3",
-	"Packages": [
-		"github.com/go-yaml/yaml",
-		"github.com/ainoya/glog",
-		"github.com/stretchr/testify",
-		"github.com/andybons/hipchat",
-		"github.com/tbruyelle/hipchat-go/hipchat",
-		"github.com/google/go-github/github",
-		"code.google.com/p/goauth2/oauth",
-		"github.com/stretchr/objx",
-		"github.com/google/go-querystring/query"
-	],
-	"Deps": [
-		{
-			"ImportPath": "code.google.com/p/goauth2/oauth",
-			"Rev": "afe77d958c70"
-		},
-		{
-			"ImportPath": "github.com/ainoya/glog",
-			"Rev": "20260dceee553e514cce6bdaea44664cc4398759"
-		},
-		{
-			"ImportPath": "github.com/andybons/hipchat",
-			"Rev": "08bf65eade11bf8d584e933d01a35c2799c36ff4"
-		},
-		{
-			"ImportPath": "github.com/go-yaml/yaml",
-			"Rev": "1b9791953ba4027efaeb728c7355e542a203be5e"
-		},
-		{
-			"ImportPath": "github.com/google/go-github/github",
-			"Rev": "1e55bf6be814270d7cc31a60868c4bd89e4e68c0"
-		},
-		{
-			"ImportPath": "github.com/google/go-querystring/query",
-			"Rev": "2a60fc2ba6c19de80291203597d752e9ba58e4c0"
-		},
-		{
-			"ImportPath": "github.com/stretchr/objx",
-			"Rev": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94"
-		},
-		{
-			"ImportPath": "github.com/stretchr/testify",
-			"Rev": "de7fcff264cd05cc0c90c509ea789a436a0dd206"
-		},
-		{
-			"ImportPath": "github.com/tbruyelle/hipchat-go/hipchat",
-			"Rev": "7fdd5b2bf90aef87fd0fb5238b0fa72559e11736"
-		},
-		{
-			"ImportPath": "gopkg.in/check.v1",
-			"Rev": "11d3bc7aa68e238947792f30573146a3231fc0f1"
-		},
-		{
-			"ImportPath": "gopkg.in/yaml.v1",
-			"Rev": "9f9df34309c04878acc86042b16630b0f696e1de"
-		}
-	]
+    "ImportPath": ".",
+    "GoVersion": "go1.3",
+    "Packages": [
+        "github.com/go-yaml/yaml",
+        "github.com/ainoya/glog",
+        "github.com/stretchr/testify",
+        "github.com/andybons/hipchat",
+        "github.com/tbruyelle/hipchat-go/hipchat",
+        "github.com/google/go-github/github",
+        "github.com/stretchr/objx",
+        "github.com/google/go-querystring/query",
+        "golang.org/x/oauth2",
+        "golang.org/x/net/context"
+    ],
+    "Deps": [
+      {
+          "ImportPath": "golang.org/x/net/context",
+          "Rev": "972f0c5fbe4ae29e666c3f78c3ed42ae7a448b0a"
+      },
+      {
+          "ImportPath": "golang.org/x/oauth2",
+          "Rev": "8a57ed94ffd43444c0879fe75701732a38afc985"
+      },
+      {
+          "ImportPath": "github.com/ainoya/glog",
+          "Rev": "20260dceee553e514cce6bdaea44664cc4398759"
+      },
+      {
+          "ImportPath": "github.com/andybons/hipchat",
+          "Rev": "08bf65eade11bf8d584e933d01a35c2799c36ff4"
+      },
+      {
+          "ImportPath": "github.com/go-yaml/yaml",
+          "Rev": "1b9791953ba4027efaeb728c7355e542a203be5e"
+      },
+      {
+          "ImportPath": "github.com/google/go-github/github",
+          "Rev": "1e55bf6be814270d7cc31a60868c4bd89e4e68c0"
+      },
+      {
+          "ImportPath": "github.com/google/go-querystring/query",
+          "Rev": "2a60fc2ba6c19de80291203597d752e9ba58e4c0"
+      },
+      {
+          "ImportPath": "github.com/stretchr/objx",
+          "Rev": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94"
+      },
+      {
+          "ImportPath": "github.com/stretchr/testify",
+          "Rev": "de7fcff264cd05cc0c90c509ea789a436a0dd206"
+      },
+      {
+          "ImportPath": "github.com/tbruyelle/hipchat-go/hipchat",
+          "Rev": "7fdd5b2bf90aef87fd0fb5238b0fa72559e11736"
+      },
+      {
+          "ImportPath": "gopkg.in/check.v1",
+          "Rev": "11d3bc7aa68e238947792f30573146a3231fc0f1"
+      },
+      {
+          "ImportPath": "gopkg.in/yaml.v1",
+          "Rev": "9f9df34309c04878acc86042b16630b0f696e1de"
+      }
+    ]
 }

--- a/services/github.go
+++ b/services/github.go
@@ -22,7 +22,7 @@ import (
 	"container/list"
 	"regexp"
 
-	"code.google.com/p/goauth2/oauth"
+	"golang.org/x/oauth2"
 	"github.com/google/go-github/github"
 	"github.com/walter-cd/walter/log"
 )
@@ -47,10 +47,11 @@ func (githubClient *GitHubClient) GetUpdateFilePath() string {
 
 //RegisterResult registers the supplied result
 func (githubClient *GitHubClient) RegisterResult(result Result) error {
-	t := &oauth.Transport{
-		Token: &oauth.Token{AccessToken: githubClient.Token},
-	}
-	client := github.NewClient(t.Client())
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: githubClient.Token},
+	)
+	tc := oauth2.NewClient(oauth2.NoContext, ts)
+	client := github.NewClient(tc)
 
 	log.Info("Submitting result")
 	repositories := client.Repositories
@@ -75,10 +76,11 @@ func (githubClient *GitHubClient) RegisterResult(result Result) error {
 func (githubClient *GitHubClient) GetCommits(update Update) (*list.List, error) {
 	log.Info("getting commits\n")
 	commits := list.New()
-	t := &oauth.Transport{
-		Token: &oauth.Token{AccessToken: githubClient.Token},
-	}
-	client := github.NewClient(t.Client())
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: githubClient.Token},
+	)
+	tc := oauth2.NewClient(oauth2.NoContext, ts)
+	client := github.NewClient(tc)
 
 	// get a list of pull requests with Pull Request API
 	pullreqs, _, err := client.PullRequests.List(


### PR DESCRIPTION
Walter build fails because it depends on deprecated library (https://code.google.com/archive/p/goauth2/).

This patch fixes a build error.