### PR TITLE
Combine stdout and stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,10 +297,11 @@ service:
 ## Reusing the results from stages
 
 Walter stores the results of preceding stages. The stages can make use of the results of finished stages using the three special
-variables (__OUT, __ERR and __RESULT) in Walter configuration files.
+variables (__OUT, __ERR, __COMBINED and __RESULT) in Walter configuration files.
 
 * **__OUT** -  output flushed to standard output 
 * **__ERR** - output flushed to standard error 
+* **__COMBINED** - combined output of stdout and stderr
 * **__RESULT** - execution result (true or false)
 
 The three variables are maps whose keys are stage names and the value are results of the stages. For example, we want the standard output

--- a/config/envvar.go
+++ b/config/envvar.go
@@ -39,7 +39,7 @@ type EnvVariables struct {
 func NewEnvVariables() *EnvVariables {
 	envmap := loadEnvMap()
 	envPattern, _ := regexp.Compile("[$]([a-zA-Z_]+)")
-	spPattern, _ := regexp.Compile("(__RESULT|__OUT|__ERR)\\[\"([a-zA-Z_0-9 ]+)\"\\]")
+	spPattern, _ := regexp.Compile("(__RESULT|__OUT|__ERR|__COMBINED)\\[\"([a-zA-Z_0-9 ]+)\"\\]")
 
 	return &EnvVariables{
 		variables:  &envmap,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -118,6 +118,7 @@ func (e *Engine) executeStage(stage stages.Stage, received []stages.Mediator) st
 		result = strconv.FormatBool(stage.(stages.Runner).Run())
 		e.EnvVariables.ExportSpecialVariable("__OUT[\""+stage.GetStageName()+"\"]", stage.GetOutResult())
 		e.EnvVariables.ExportSpecialVariable("__ERR[\""+stage.GetStageName()+"\"]", stage.GetErrResult())
+		e.EnvVariables.ExportSpecialVariable("__COMBINED[\""+stage.GetStageName()+"\"]", stage.GetCombinedResult())
 		e.EnvVariables.ExportSpecialVariable("__RESULT[\""+stage.GetStageName()+"\"]", result)
 	} else {
 		log.Warnf("Execution is skipped: %v", stage.GetStageName())

--- a/pipelines/pipeline.go
+++ b/pipelines/pipeline.go
@@ -93,6 +93,8 @@ func (resources *Pipeline) GetStageResult(name string, stageType string) (string
 			return stage.GetOutResult(), nil
 		case "__ERR":
 			return stage.GetErrResult(), nil
+		case "__COMBINED":
+			return stage.GetCombinedResult(), nil
 		case "__RESULT":
 			return strconv.FormatBool(stage.GetReturnValue()), nil
 		default:

--- a/stages/base_stage.go
+++ b/stages/base_stage.go
@@ -48,6 +48,9 @@ type BaseStage struct {
 	// Results of stderr flush by the stage.
 	ErrResult string
 
+	// Results of stdout and stderr combined by the stage
+	CombinedResult string
+
 	// Return value of the stage
 	ReturnValue bool
 
@@ -152,6 +155,16 @@ func (b *BaseStage) GetErrResult() string {
 // SetErrResult sets standard error results.
 func (b *BaseStage) SetErrResult(result string) {
 	b.ErrResult = result
+}
+
+// GetCombinedResult returns stdout and stderr combined results.
+func (b *BaseStage) GetCombinedResult() string {
+	return b.CombinedResult
+}
+
+// SetErrResult sets stdout and stderr combined results.
+func (b *BaseStage) SetCombinedResult(result string) {
+	b.CombinedResult = result
 }
 
 // GetReturnValue returns return value of the stage

--- a/stages/stage.go
+++ b/stages/stage.go
@@ -39,6 +39,8 @@ type Stage interface {
 	SetOutResult(string)
 	GetErrResult() string
 	SetErrResult(string)
+	GetCombinedResult() string
+	SetCombinedResult(string)
 	GetReturnValue() bool
 }
 


### PR DESCRIPTION
Most of CI tools (Jenkins, Wercker and so on) display the log without any distinction of stdout and stderr.
I'd like  walter-server to display the log in the same way.

This PR is for this purpose.

Also I've simplified the code to get stdout and stderr.