### PR TITLE
Fix small typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ You can define parallel tasks.
 build:
    tasks:
      - name: parallel tasks
-       paralle:
+       parallel:
            - name: task 1
              command: echo task 1
            - name: task 2


### PR DESCRIPTION
Why you made the change:

I did this so that people wouldn't accidentally copy and paste a broken
example.